### PR TITLE
Add missing custom dictionary entries

### DIFF
--- a/custom_dict.txt
+++ b/custom_dict.txt
@@ -1057,6 +1057,7 @@ Irizarry
 IronFrame
 IRSA
 ISAPI
+iSCSI
 Isenberg
 IServiceProvider
 ISTIO_MUTUAL
@@ -1907,6 +1908,7 @@ Route53
 RouteAuthSpecs
 routeToSecondaryMembers
 RoutingAsyncEventListener
+RPi
 RSA
 RSocket(-based)?
 Ruckle


### PR DESCRIPTION
Hey @dashaun! Just one small tweak for your PR, our current spellcheck solution maintains a custom dictionary of words not in the tools internal one. This PR just adds a couple missing acronyms. Once you merge this, it should be reflected in your PR to the main repo and get the tests passing, and I can merge your changes. Thanks! :) 